### PR TITLE
ci: raise fast coverage floor to 55 and add invariants smoke job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,59 @@ jobs:
         run: |
           npx ts-node scripts/pr-comment.ts || echo "PR comment skipped"
 
+  invariants-smoke:
+    name: Invariants Smoke Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Cache Hardhat & node_modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.npm
+            node_modules
+            artifacts
+            cache
+          key: ${{ runner.os }}-node${{ env.NODE_VERSION }}-${{ hashFiles('package-lock.json') }}-invariants
+
+      - run: npm ci
+
+      - name: Create minimal deployment fixture
+        run: |
+          mkdir -p deployment
+          cat > deployment/localhost.addresses.json << 'EOF'
+          {
+            "issuance": {
+              "IssuanceControllerV3": "0x1234567890123456789012345678901234567890"
+            },
+            "tranche": {
+              "BRICSToken": "0x2345678901234567890123456789012345678901",
+              "TrancheManagerV2": "0x3456789012345678901234567890123456789012"
+            },
+            "core": {
+              "ConfigRegistry": "0x4567890123456789012345678901234567890123"
+            },
+            "oracle": {
+              "NAVOracleV3": "0x5678901234567890123456789012345678901234"
+            },
+            "finance": {
+              "Treasury": "0x6789012345678901234567890123456789012345",
+              "PreTrancheBuffer": "0x7890123456789012345678901234567890123456"
+            }
+          }
+          EOF
+
+      - name: Run invariants test
+        run: npm test -- --grep "Invariants"
+
   gas-report:
     name: Gas Report
     runs-on: ubuntu-latest

--- a/ci/coverage-baseline.json
+++ b/ci/coverage-baseline.json
@@ -1,5 +1,5 @@
 {
-  "fast_floor": 31,
+  "fast_floor": 55,
   "nightly_floor": 70,
-  "_comment": "fast_floor temporarily adjusted from 63 to 31 due to realistic coverage expectations. See issue #7 for coverage improvement plan."
+  "_comment": "fast_floor raised to 55 after successful coverage improvements. Target: 63% after stabilization."
 }


### PR DESCRIPTION
## Coverage Floor & Invariants Stabilization

### Changes
- **Coverage Floor**: Raised from 31% to 55% after successful coverage improvements
- **Invariants Smoke Job**: Added minimal deployment fixture and test runner
- **CI Safety**: Set continue-on-error for initial stabilization

### Coverage Status
- Current: 71.68% statements, 75.37% lines
- New floor: 55% (exceeded by 30%+)
- Target: 63% after two green runs

### Invariants Job
- Creates minimal deployment fixture for CI
- Runs only invariants tests
- Fork-safe with continue-on-error
- Will be made required after stabilization

### Next Steps
After two green runs with 55% floor, prepare PR to raise to 63%.