### PR TITLE
ci: add ABI/storage validation to audit-bundle job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1100,6 +1100,11 @@ jobs:
         run: |
           yarn hardhat compile
 
+      - name: Validate ABI/storage compatibility
+        run: |
+          yarn audit:abi
+          yarn audit:abi:check
+
       - name: Generate audit artifacts
         run: |
           yarn audit:manifest


### PR DESCRIPTION
Add ABI/storage validation steps to the audit-bundle CI job to ensure compatibility checks are run during scheduled builds.