### PR TITLE
tests: stabilize MINTER_ROLE mint spec

### DIFF
--- a/contracts/mocks/MockMemberRegistry.sol
+++ b/contracts/mocks/MockMemberRegistry.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.20;
 
 interface IMemberRegistryLike {
     function isMember(address who) external view returns (bool);
+    function canSend(address from) external view returns (bool);
+    function canReceive(address to) external view returns (bool);
 }
 
 contract MockMemberRegistry is IMemberRegistryLike {
@@ -16,5 +18,13 @@ contract MockMemberRegistry is IMemberRegistryLike {
 
     function isMember(address who) external view returns (bool) {
         return members[who];
+    }
+
+    function canSend(address from) external view returns (bool) {
+        return members[from];
+    }
+
+    function canReceive(address to) external view returns (bool) {
+        return members[to];
     }
 }


### PR DESCRIPTION
Fix failing Release Validation test: use dynamic role id + correct revert type. Tests/mocks only; no runtime changes.