### PR TITLE
tests: RAY canonicalization sweep

### DIFF
--- a/test/issue61.fixed.probe.spec.ts
+++ b/test/issue61.fixed.probe.spec.ts
@@ -58,7 +58,7 @@ describe("Issue #61 fixed – probe next failing branch", () => {
     await controller.connect(ops).grantRole(await controller.OPS_ROLE(), ops.address);
     
     // Set up NAV oracle
-    await setNavCompat(oracle, ethers.parseEther("1.0") * 10n ** 9n); // 1.0 NAV in ray format
+    await setNavCompat(oracle, ethers.parseUnits("1.0", 27)); // 1.0 NAV in ray format
     
     // Set up sovereign configuration
     const SOVEREIGN_CODE = ethers.encodeBytes32String("TEST");

--- a/test/issue61.no-shadow.spec.ts
+++ b/test/issue61.no-shadow.spec.ts
@@ -58,7 +58,7 @@ describe("Issue #61 – no shadowing in mintFor", () => {
     await controller.connect(deployer).grantRole(await controller.OPS_ROLE(), deployer.address);
     
     // Set up NAV oracle
-    await setNavCompat(oracle, ethers.parseEther("1.0") * 10n ** 9n); // 1.0 NAV in ray format
+    await setNavCompat(oracle, ethers.parseUnits("1.0", 27)); // 1.0 NAV in ray format
     
     // Set up sovereign configuration
     const SOVEREIGN_CODE = ethers.encodeBytes32String("TEST");


### PR DESCRIPTION
Replace legacy WAD×1e9 patterns with parseUnits(...,27). Test-only cleanup.