### PR TITLE
ci: mocha retries via workflow only

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,8 +49,8 @@ jobs:
           PRICING_PROVIDER: stub
           BANK_DATA_MODE: off
         run: |
-          yarn hardhat test test/security/precision.spec.ts --grep SMOKE
-          yarn hardhat test test/security/reentrancy.spec.ts --grep SMOKE
+          yarn hardhat test test/security/precision.spec.ts --grep SMOKE --retries 1
+          yarn hardhat test test/security/reentrancy.spec.ts --grep SMOKE --retries 1
 
   test:
     runs-on: ubuntu-latest
@@ -104,4 +104,4 @@ jobs:
         env:
           PRICING_PROVIDER: stub
           BANK_DATA_MODE: off
-        run: yarn test
+        run: yarn test --retries 1


### PR DESCRIPTION
Reduce flake risk without touching runner code; add --retries 1 to CI test steps only.