### PR TITLE
ci: auto-comment on failing tests runs

### DIFF
--- a/.github/workflows/ci-fail-comment.yml
+++ b/.github/workflows/ci-fail-comment.yml
@@ -1,0 +1,60 @@
+name: ci-fail-comment
+
+on:
+  workflow_run:
+    workflows: ["tests"]
+    types: [completed]
+
+permissions:
+  checks: read
+  pull-requests: write
+  contents: read
+
+jobs:
+  comment-on-fail:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find associated PR and comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const {owner, repo} = context.repo;
+            const runId = context.payload.workflow_run.id;
+
+            // Get jobs for the failed run and basic info
+            const jobs = await github.rest.actions.listJobsForWorkflowRun({ owner, repo, run_id: runId, per_page: 100 });
+            const failedJobs = (jobs.data.jobs || []).filter(j => j.conclusion === 'failure');
+            const summary = failedJobs.map(j => `- **${j.name}**`).join('\n') || '- (no job details)';
+
+            // Find PRs associated with this run
+            const { data: prs } = await github.rest.pulls.list({ owner, repo, state: 'open', per_page: 50 });
+
+            // Match by head SHA
+            const runHeadSha = context.payload.workflow_run.head_sha;
+            const target = prs.find(pr => pr.head && pr.head.sha === runHeadSha);
+            if (!target) {
+              core.info('No open PR matched the failed run head SHA; skipping.');
+              return;
+            }
+
+            const runUrl = context.payload.workflow_run.html_url;
+            const body = [
+              `❌ **CI failed** for workflow **tests**.`,
+              ``,
+              `**Failed jobs:**`,
+              summary,
+              ``,
+              `**Run:** ${runUrl}`,
+              ``,
+              `Tips:`,
+              `- Check guardrails step output for drift (raw time ops / legacy RAY).`,
+              `- For flake-like behavior, consider rerun; retries are CI-only.`,
+              ``,
+              `_This comment was posted automatically when the tests workflow failed._`
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: target.number, body
+            });
+            core.info(`Commented on PR #${target.number}`);

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,13 @@ jobs:
           key: ${{ runner.os }}-hardhat-${{ hashFiles('hardhat.config.ts') }}-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-hardhat-
+      - name: Guardrails scan (non-blocking)
+        run: |
+          echo "Scanning for raw time ops and legacy RAY..."
+          set +e
+          grep -RIn --include="*.ts" "evm_(increaseTime|setNextBlockTimestamp)|evm_mine" test/ || true
+          grep -RIn --include="*.ts" 'parseEther("1(\.[0-9]+)?"\) \* 10n \*\* 9n' test/ || true
+          set -e
       - name: Run fast smokes
         env:
           PRICING_PROVIDER: stub
@@ -121,6 +128,13 @@ jobs:
           key: ${{ runner.os }}-hardhat-${{ hashFiles('hardhat.config.ts') }}-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-hardhat-
+      - name: Guardrails scan (non-blocking)
+        run: |
+          echo "Scanning for raw time ops and legacy RAY..."
+          set +e
+          grep -RIn --include="*.ts" "evm_(increaseTime|setNextBlockTimestamp)|evm_mine" test/ || true
+          grep -RIn --include="*.ts" 'parseEther("1(\.[0-9]+)?"\) \* 10n \*\* 9n' test/ || true
+          set -e
       - name: Guardrails (tests)
         run: bash scripts/check-usdc-ether.sh
       - name: Run tests


### PR DESCRIPTION
When the tests workflow fails, post a concise comment on the associated PR listing failed jobs and linking to the run.