### PR TITLE
ci(guardrails): log summary + PR auto-comment; docs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      GUARDRAILS_ARTIFACT_NAME: guardrails-report-smokes
     steps:
       - uses: actions/checkout@v3
         with:
@@ -65,6 +67,54 @@ jobs:
           path: guardrails-report.txt
           if-no-files-found: ignore
           retention-days: 7
+      - name: Guardrails PR comment (non-blocking)
+        if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'guardrails-report.txt';
+            if (!fs.existsSync(path)) {
+              core.info('No guardrails-report.txt found (skipping comment).');
+              return;
+            }
+            const txt = fs.readFileSync(path, 'utf8');
+            function count(sectionTitle) {
+              const re = new RegExp(`^== ${sectionTitle} ==[\\s\\S]*?(?=^== |\\Z)`, 'm');
+              const m = txt.match(re);
+              if (!m) return 0;
+              return m[0].split('\n').slice(1).filter(l => l.trim().length > 0).length;
+            }
+            const counts = {
+              'raw time ops (evm_*)': count('raw time ops (evm_*)'),
+              'legacy RAY math (parseEther(...) * 10n ** 9n)': count('legacy RAY math (parseEther(...) * 10n ** 9n)'),
+              'focused tests (.only)': count('focused tests (.only)'),
+              'console.log in tests': count('console.log in tests'),
+              'hardcoded 0x addresses (excluding mocks/fixtures/json)': count('hardcoded 0x addresses (excluding mocks/fixtures/json)')
+            };
+            const total = Object.values(counts).reduce((a,b)=>a+b,0);
+            core.info(`Guardrails counts: ${JSON.stringify(counts)}`);
+            if (total === 0) return; // nothing to report
+            const runUrl = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const artifact = process.env.GUARDRAILS_ARTIFACT_NAME || 'guardrails-report';
+            const lines = Object.entries(counts)
+              .filter(([,c])=>c>0)
+              .map(([k,c])=>`- ${k}: **${c}**`)
+              .join('\n');
+            const body = [
+              '🛡️ **Guardrails findings**',
+              '',
+              lines,
+              '',
+              `Details: download artifact **${artifact}**`,
+              `Run: ${runUrl}`
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body
+            });
       - name: Run fast smokes
         env:
           PRICING_PROVIDER: stub
@@ -80,6 +130,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      GUARDRAILS_ARTIFACT_NAME: guardrails-report-test
     steps:
       - uses: actions/checkout@v3
         with:
@@ -143,6 +195,54 @@ jobs:
           path: guardrails-report.txt
           if-no-files-found: ignore
           retention-days: 7
+      - name: Guardrails PR comment (non-blocking)
+        if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'guardrails-report.txt';
+            if (!fs.existsSync(path)) {
+              core.info('No guardrails-report.txt found (skipping comment).');
+              return;
+            }
+            const txt = fs.readFileSync(path, 'utf8');
+            function count(sectionTitle) {
+              const re = new RegExp(`^== ${sectionTitle} ==[\\s\\S]*?(?=^== |\\Z)`, 'm');
+              const m = txt.match(re);
+              if (!m) return 0;
+              return m[0].split('\n').slice(1).filter(l => l.trim().length > 0).length;
+            }
+            const counts = {
+              'raw time ops (evm_*)': count('raw time ops (evm_*)'),
+              'legacy RAY math (parseEther(...) * 10n ** 9n)': count('legacy RAY math (parseEther(...) * 10n ** 9n)'),
+              'focused tests (.only)': count('focused tests (.only)'),
+              'console.log in tests': count('console.log in tests'),
+              'hardcoded 0x addresses (excluding mocks/fixtures/json)': count('hardcoded 0x addresses (excluding mocks/fixtures/json)')
+            };
+            const total = Object.values(counts).reduce((a,b)=>a+b,0);
+            core.info(`Guardrails counts: ${JSON.stringify(counts)}`);
+            if (total === 0) return; // nothing to report
+            const runUrl = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const artifact = process.env.GUARDRAILS_ARTIFACT_NAME || 'guardrails-report';
+            const lines = Object.entries(counts)
+              .filter(([,c])=>c>0)
+              .map(([k,c])=>`- ${k}: **${c}**`)
+              .join('\n');
+            const body = [
+              '🛡️ **Guardrails findings**',
+              '',
+              lines,
+              '',
+              `Details: download artifact **${artifact}**`,
+              `Run: ${runUrl}`
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body
+            });
       - name: Guardrails (tests)
         run: bash scripts/check-usdc-ether.sh
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,10 +80,22 @@ jobs:
             }
             const txt = fs.readFileSync(path, 'utf8');
             function count(sectionTitle) {
-              const re = new RegExp(`^== ${sectionTitle} ==[\\s\\S]*?(?=^== |\\Z)`, 'm');
-              const m = txt.match(re);
-              if (!m) return 0;
-              return m[0].split('\n').slice(1).filter(l => l.trim().length > 0).length;
+              const lines = txt.split('\n');
+              let inSection = false;
+              let count = 0;
+              for (const line of lines) {
+                if (line.startsWith('==== ') && line.includes(sectionTitle)) {
+                  inSection = true;
+                  continue;
+                }
+                if (inSection && line.startsWith('==== ')) {
+                  break;
+                }
+                if (inSection && line.trim().length > 0) {
+                  count++;
+                }
+              }
+              return count;
             }
             const counts = {
               'raw time ops (evm_*)': count('raw time ops (evm_*)'),
@@ -208,10 +220,22 @@ jobs:
             }
             const txt = fs.readFileSync(path, 'utf8');
             function count(sectionTitle) {
-              const re = new RegExp(`^== ${sectionTitle} ==[\\s\\S]*?(?=^== |\\Z)`, 'm');
-              const m = txt.match(re);
-              if (!m) return 0;
-              return m[0].split('\n').slice(1).filter(l => l.trim().length > 0).length;
+              const lines = txt.split('\n');
+              let inSection = false;
+              let count = 0;
+              for (const line of lines) {
+                if (line.startsWith('==== ') && line.includes(sectionTitle)) {
+                  inSection = true;
+                  continue;
+                }
+                if (inSection && line.startsWith('==== ')) {
+                  break;
+                }
+                if (inSection && line.trim().length > 0) {
+                  count++;
+                }
+              }
+              return count;
             }
             const counts = {
               'raw time ops (evm_*)': count('raw time ops (evm_*)'),

--- a/README.md
+++ b/README.md
@@ -132,6 +132,16 @@ REPORT_GAS=true npm test
 - Governance pause/resume functionality  
 - Redemption claim mint+burn (gated to smokes lane via `CI_SMOKES_ONLY`)
 
+#### CI smokes & guardrails
+
+- **Smokes lane** runs a tiny set of <~30s tests (precision, reentrancy, governance, redemption) for fast signal.  
+- **Guardrails v2** runs on every job (non-blocking) and uploads a `guardrails-report` artifact. It scans for:
+  - Raw EVM time ops (`evm_increaseTime`, `evm_mine`, etc.)
+  - Legacy RAY math (WAD×1e9 patterns)
+  - Focused tests (`.only`), `console.log` in tests
+  - Hardcoded `0x…` addrs (excluding mocks/fixtures/json)
+- If findings exist on a PR, the workflow auto-comments with counts + artifact link.
+
 ### Deployment
 ```bash
 # Deploy to local network

--- a/scripts/guardrails/scan.sh
+++ b/scripts/guardrails/scan.sh
@@ -32,3 +32,23 @@ if [ -s guardrails-report.txt ]; then
 else
   echo "No guardrails findings."
 fi
+
+# ---- summary (logs) ----
+if [ -f guardrails-report.txt ]; then
+  sec_count () {
+    # print lines between "== <section> ==" and next "== " section, count non-empty
+    awk "/^== $1 ==/{flag=1;next}/^== /{flag=0} flag" guardrails-report.txt | grep -c . || true
+  }
+  c_time=$(sec_count "raw time ops (evm_*)")
+  c_ray=$(sec_count "legacy RAY math (parseEther(...) * 10n ** 9n)")
+  c_only=$(sec_count "focused tests (.only)")
+  c_log=$(sec_count "console.log in tests")
+  c_addr=$(sec_count "hardcoded 0x addresses (excluding mocks/fixtures/json)")
+  echo "::group::Guardrails summary"
+  echo "RAW EVM TIME OPS:     $c_time"
+  echo "LEGACY RAY MATH:      $c_ray"
+  echo "FOCUSED TESTS (.only):$c_only"
+  echo "CONSOLE LOGS:         $c_log"
+  echo "HARDCODED 0x ADDRS:   $c_addr"
+  echo "::endgroup::"
+fi


### PR DESCRIPTION
Non-blocking UX: print counts in logs, auto-comment on PRs when guardrails find hits, and document smokes/guardrails in README. No app/test semantics changed.