### PR TITLE
ci(guardrails): expand to 8 checks (add TODO/FIXME, hardhat/console, mocha only)

### DIFF
--- a/scripts/guardrails/scan.sh
+++ b/scripts/guardrails/scan.sh
@@ -26,6 +26,19 @@ section "hardcoded 0x addresses (excluding mocks/fixtures/json)"
 grep -RInE '0x[a-fA-F0-9]{40}' -- test contracts 2>/dev/null \
   | grep -Ev '(mocks?/|Mock|fixtures?/|\.json$)' || true | tee -a guardrails-report.txt
 
+# 6) TODO/FIXME markers (case-insensitive, exclude docs/README/CHANGELOG/.md)
+section "TODO/FIXME markers (excluding docs/README/CHANGELOG/.md)"
+grep -RIni 'TODO|FIXME' -- src test 2>/dev/null \
+  | grep -Ev '(docs/|README|CHANGELOG|\.md$)' || true | tee -a guardrails-report.txt
+
+# 7) hardhat/console imports
+section "hardhat/console imports"
+grep -RInE '(require|import).*hardhat/console' -- src test || true | tee -a guardrails-report.txt
+
+# 8) Mocha "only" markers (backup to .only check)
+section "mocha only markers (backup)"
+grep -RInE '\.only\(' -- src test || true | tee -a guardrails-report.txt
+
 echo
 if [ -s guardrails-report.txt ]; then
   echo "Guardrails findings captured above (non-blocking)."
@@ -44,11 +57,17 @@ if [ -f guardrails-report.txt ]; then
   c_only=$(sec_count "focused tests (.only)")
   c_log=$(sec_count "console.log in tests")
   c_addr=$(sec_count "hardcoded 0x addresses (excluding mocks/fixtures/json)")
+  c_todo=$(sec_count "TODO/FIXME markers (excluding docs/README/CHANGELOG/.md)")
+  c_console=$(sec_count "hardhat/console imports")
+  c_mocha=$(sec_count "mocha only markers (backup)")
   echo "::group::Guardrails summary"
   echo "RAW EVM TIME OPS:     $c_time"
   echo "LEGACY RAY MATH:      $c_ray"
   echo "FOCUSED TESTS (.only):$c_only"
   echo "CONSOLE LOGS:         $c_log"
   echo "HARDCODED 0x ADDRS:   $c_addr"
+  echo "TODO/FIXME MARKERS:   $c_todo"
+  echo "HARDHAT/CONSOLE:      $c_console"
+  echo "MOCHA ONLY MARKERS:   $c_mocha"
   echo "::endgroup::"
 fi


### PR DESCRIPTION
Expand guardrails to 8 comprehensive checks. Adds TODO/FIXME markers, hardhat/console imports, and mocha only markers. Non-blocking script-only changes.