### PR TITLE
ci: fix timing calculation + add anti-duplication for guardrails comments

### DIFF
--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -71,9 +71,11 @@ jobs:
             const smokesMeds = median(jobDurations.map(r => r.smokes));
             const testMeds   = median(jobDurations.map(r => r.test));
 
-            // 5) Timing analysis from artifacts (7-day medians)
+            // 5) Timing analysis from artifacts (preferred over run metadata)
             const { execSync } = require('child_process');
             let timingAnalysis = '';
+            let usedArtifacts = false;
+            
             try {
               // Get recent runs and download timing artifacts
               const recentRuns = okRuns.slice(0, 20); // Last 20 successful runs
@@ -106,6 +108,7 @@ jobs:
               }
               
               if (timingData.length > 0) {
+                usedArtifacts = true;
                 const smokesTimings = timingData.filter(t => t.job === 'smokes').map(t => t.duration);
                 const testTimings = timingData.filter(t => t.job === 'test').map(t => t.duration);
                 
@@ -119,7 +122,11 @@ jobs:
                 timingAnalysis = `\n**Timing Analysis (7-day medians from artifacts):**\n- Smokes: ${smokesMedian}s (${smokesDelta})\n- Test: ${testMedian}s (${testDelta})\n`;
               }
             } catch (e) {
-              timingAnalysis = '\n**Timing Analysis:** No timing data available yet.\n';
+              // Fall back to run metadata
+            }
+            
+            if (!usedArtifacts) {
+              timingAnalysis = `\n**Timing Analysis (fallback to run metadata):**\n- Smokes: ${smokesMeds ? smokesMeds + 's' : 'n/a'}\n- Test: ${testMeds ? testMeds + 's' : 'n/a'}\n`;
             }
 
             // 6) Open PRs with failing checks

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           fetch-depth: 0
           submodules: false
+      - name: Record job start
+        id: record_start
+        run: echo "JOB_START_TS=$(date +%s)" >> "$GITHUB_ENV"
       - name: Safe git (guarded)
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -107,6 +110,22 @@ jobs:
             const total = Object.values(counts).reduce((a,b)=>a+b,0);
             core.info(`Guardrails counts: ${JSON.stringify(counts)}`);
             if (total === 0) return; // nothing to report
+            
+            // Check for existing comment to avoid duplicates
+            const marker = `[guardrails-report:${process.env.GITHUB_RUN_ID}:${process.env.GITHUB_JOB}]`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              per_page: 100
+            });
+            
+            const existingComment = comments.find(c => c.body && c.body.includes(marker));
+            if (existingComment) {
+              core.info('Guardrails comment already exists, skipping duplicate.');
+              return;
+            }
+            
             const runUrl = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
             const artifact = process.env.GUARDRAILS_ARTIFACT_NAME || 'guardrails-report';
             const lines = Object.entries(counts)
@@ -119,7 +138,9 @@ jobs:
               lines,
               '',
               `Details: download artifact **${artifact}**`,
-              `Run: ${runUrl}`
+              `Run: ${runUrl}`,
+              '',
+              marker
             ].join('\n');
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -137,13 +158,24 @@ jobs:
           yarn hardhat test test/security/reentrancy.spec.ts --grep SMOKE
           # Include redemption smoke only in the smokes lane
           yarn hardhat test test/nav.redemption.simple.spec.ts --grep "SMOKE"
-      - name: Record timing
+      - name: Append timing CSV
         if: always()
+        shell: bash
         run: |
-          duration=$(($(date +%s) - $(date -d "${{ env.GITHUB_JOB_STARTED_AT }}" +%s)))
-          echo "$(date -u +%Y-%m-%dT%H:%M:%SZ),smokes,$duration,${{ steps.cache-yarn.outputs.cache-hit == 'true' || 'false'}}" >> ci-timings.txt
-          if [ $duration -gt 120 ]; then
-            echo "⚠️ Budget warning: smokes job took ${duration}s (threshold: 120s)" | tee -a $GITHUB_STEP_SUMMARY
+          NOW=$(date +%s)
+          : "${JOB_START_TS:=0}"
+          if [ "$JOB_START_TS" -eq 0 ]; then
+            echo "WARN: JOB_START_TS missing; setting duration=0" >&2
+            DURATION=0
+          else
+            DURATION=$(( NOW - JOB_START_TS ))
+          fi
+          CACHE_HIT="${{ steps.cache-yarn.outputs.cache-hit || 'false' }}"
+          TS_ISO=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          JOB_NAME="${{ github.job }}"
+          echo "${TS_ISO},${JOB_NAME},${DURATION},${CACHE_HIT}" >> ci-timings.txt
+          if [ $DURATION -gt 120 ]; then
+            echo "⚠️ Budget warning: smokes job took ${DURATION}s (threshold: 120s)" | tee -a $GITHUB_STEP_SUMMARY
           fi
       - name: Upload timing data
         if: always()
@@ -165,6 +197,9 @@ jobs:
         with:
           fetch-depth: 0
           submodules: false
+      - name: Record job start
+        id: record_start
+        run: echo "JOB_START_TS=$(date +%s)" >> "$GITHUB_ENV"
       # Assert no submodules and clean any cached submodule state
       - name: Assert no submodules
         run: |
@@ -263,6 +298,22 @@ jobs:
             const total = Object.values(counts).reduce((a,b)=>a+b,0);
             core.info(`Guardrails counts: ${JSON.stringify(counts)}`);
             if (total === 0) return; // nothing to report
+            
+            // Check for existing comment to avoid duplicates
+            const marker = `[guardrails-report:${process.env.GITHUB_RUN_ID}:${process.env.GITHUB_JOB}]`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              per_page: 100
+            });
+            
+            const existingComment = comments.find(c => c.body && c.body.includes(marker));
+            if (existingComment) {
+              core.info('Guardrails comment already exists, skipping duplicate.');
+              return;
+            }
+            
             const runUrl = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
             const artifact = process.env.GUARDRAILS_ARTIFACT_NAME || 'guardrails-report';
             const lines = Object.entries(counts)
@@ -275,7 +326,9 @@ jobs:
               lines,
               '',
               `Details: download artifact **${artifact}**`,
-              `Run: ${runUrl}`
+              `Run: ${runUrl}`,
+              '',
+              marker
             ].join('\n');
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -290,13 +343,24 @@ jobs:
           PRICING_PROVIDER: stub
           BANK_DATA_MODE: off
         run: yarn test
-      - name: Record timing
+      - name: Append timing CSV
         if: always()
+        shell: bash
         run: |
-          duration=$(($(date +%s) - $(date -d "${{ env.GITHUB_JOB_STARTED_AT }}" +%s)))
-          echo "$(date -u +%Y-%m-%dT%H:%M:%SZ),test,$duration,${{ steps.cache-yarn.outputs.cache-hit == 'true' || 'false'}}" >> ci-timings.txt
-          if [ $duration -gt 180 ]; then
-            echo "⚠️ Budget warning: test job took ${duration}s (threshold: 180s)" | tee -a $GITHUB_STEP_SUMMARY
+          NOW=$(date +%s)
+          : "${JOB_START_TS:=0}"
+          if [ "$JOB_START_TS" -eq 0 ]; then
+            echo "WARN: JOB_START_TS missing; setting duration=0" >&2
+            DURATION=0
+          else
+            DURATION=$(( NOW - JOB_START_TS ))
+          fi
+          CACHE_HIT="${{ steps.cache-yarn.outputs.cache-hit || 'false' }}"
+          TS_ISO=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          JOB_NAME="${{ github.job }}"
+          echo "${TS_ISO},${JOB_NAME},${DURATION},${CACHE_HIT}" >> ci-timings.txt
+          if [ $DURATION -gt 180 ]; then
+            echo "⚠️ Budget warning: test job took ${DURATION}s (threshold: 180s)" | tee -a $GITHUB_STEP_SUMMARY
           fi
       - name: Upload timing data
         if: always()


### PR DESCRIPTION
Fix CI duration calculation by recording job start timestamp and computing accurate durations. Add anti-duplication logic for guardrails PR comments. Update weekly audit to prefer timing artifacts over run metadata.