### PR TITLE
ci: enable manual dispatch for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on:
     branches: ['**']
   pull_request:
     branches: ['**']
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Adds workflow_dispatch so we can run smokes/test on demand. No code/semantics changes.